### PR TITLE
Fix the website for IRISnet

### DIFF
--- a/projects/2018.md
+++ b/projects/2018.md
@@ -92,7 +92,7 @@ If successful, Althea will build a decentralized alternative to centralized ISPs
  
 The ICF will occasionally make equity investments in teams we believe in that are building on Cosmos, and who are likely to have a strong impact on the Cosmos ecosystem. 
 
-**9. IRIS** [**https://www.theiris.org/**](https://www.theiris.org/)
+**9. IRIS** [**https://www.irisnet.org**](https://www.irisnet.org)
 
 **Type of Funding: Investment**
 


### PR DESCRIPTION
Fix the website for IRISnet.
It should be https://www.irisnet.org