### PR TITLE
Change DGaming to Corestar due to branding change

### DIFF
--- a/projects/2019.md
+++ b/projects/2019.md
@@ -225,7 +225,7 @@ Krypto Seoul is also an active member of the Cosmos community and advocate in th
 
 Chainflow is building a monitoring and performance dashboard that would remove the need for small validators to do manual status checking, providing an easier way to tweak key parameters and improve performance and security. Open source tools like these ultimately encourage more validator participation, and allow all validators to make their operations more streamlined and efficient. 
 
-**38. Dgaming** [**https://dgaming.com/**](https://dgaming.com/)
+**38. Corestar** [**https://corestar.io/**](https://corestar.io/)
 
 **Type of Funding: Service Agreement**
 
@@ -233,7 +233,7 @@ Chainflow is building a monitoring and performance dashboard that would remove t
  
 **TLDR:  Tendermint fork with built-in threshold BLS random beacon for tendermint-based applications that need random numbers.**
 
-The DGaming team is at a unique intersection of research, development, and engineering. The team is pursuing Tendermint developments to be applied to their gaming application, DGaming Arcade. They  will be working on a PoS implementation for building out distributed key generation for a BLS-based random beacon which can be used for DGaming Arcade. This work can help more generally inform Tendermint scaling efforts and improvements to its consensus (e.g. cryptographic sortition for validator set and randomized proposer choice).
+The Corestar team is at a unique intersection of research, development, and engineering. The team is pursuing Tendermint developments to be applied to their blockachain framework, Arcade. They  will be working on a PoS implementation for building out distributed key generation for a BLS-based random beacon which can be used for Arcade. This work can help more generally inform Tendermint scaling efforts and improvements to its consensus (e.g. cryptographic sortition for validator set and randomized proposer choice).
 
 **39. Regen** [**https://www.regen.network/**](https://www.regen.network/)
 


### PR DESCRIPTION
We've changed our brand name recently, and notified Interchain Foundation - can we update the funding document accordingly?